### PR TITLE
fix: DependencyMacro 도입 후 컴파일 충둘문제 수정

### DIFF
--- a/Projects/CoreKit/Sources/Data/Client/SwiftSoupClient/SwiftSoupClient+TestKey.swift
+++ b/Projects/CoreKit/Sources/Data/Client/SwiftSoupClient/SwiftSoupClient+TestKey.swift
@@ -11,5 +11,4 @@ import Dependencies
 
 extension SwiftSoupClient: TestDependencyKey {
     public static let testValue = Self()
-    public static let previewValue = liveValue
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#137 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `DependencyMacro` 도입 후 컴파일 충둘문제 수정

### 스크린샷 (선택)
<img width="1965" alt="스크린샷 2024-10-06 16 48 08" src="https://github.com/user-attachments/assets/c4b4860c-1255-4772-a047-08c488097970">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

### `SwiftSoupClient`의 `previewValue`를 제거하였습니다
- 저는 보통 저렇게 긴 에러로그는 GPT한테 해석시키는데, GPT가 `SwiftSoupClient`의 `DependencyKey` 관련 오류라고 언급을 해주었습니다.
- 그래서 코드를 보니 아래와 같은 코드에서 오류가 난것으로 보였습니다.
```swift
public static let previewValue = liveValue
```
- 제 생각에는 `TestDependencyKey` 프로토콜 채용 부분에 `liveValue`를 바로 호출한게 문제가 된거 같은데, 기존에는 문제 없다가 `DependencyMacro`를 도입하면서 문제가 발생한 원인을 모르겠습니다. 원인을 알고 계시다면 설명 부탁드리겠습니다!
- 혹시나 작업하시는데 문제 없었으면 `DependencyMacro`와 xcode 16의 콜라보라 추측이 됩니다...(실제로 CI/CD 워크플로우의 xcode를 16으로 올렸더니 동일한 문제가 발생했음)

close #137 
