### PR TITLE
refactor: CategoryDetailFeature 액션 수정

### DIFF
--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -45,7 +45,7 @@ public extension CategoryDetailView {
                 if let shareURL = URL(string: content.data) {
                     PokitShareSheet(
                         items: [shareURL],
-                        completion: { send(.링크_공유_완료) }
+                        completion: { send(.링크_공유_완료되었을때) }
                     )
                     .presentationDetents([.medium, .large])
                 }
@@ -55,7 +55,7 @@ public extension CategoryDetailView {
                     PokitCategorySheet(
                         selectedItem: nil,
                         list: categories.elements,
-                        action: { send(.categorySelected($0)) }
+                        action: { send(.카테고리_선택했을때($0)) }
                     )
                     .presentationDragIndicator(.visible)
                 } else {
@@ -77,7 +77,7 @@ public extension CategoryDetailView {
                     delegateSend: { store.send(.scope(.filterBottomSheet($0))) }
                 )
             }
-            .task { await send(.onAppear).finish() }
+            .task { await send(.뷰가_나타났을때).finish() }
         }
     }
 }
@@ -92,7 +92,10 @@ private extension CategoryDetailView {
                 )
             }
             PokitHeaderItems(placement: .trailing) {
-                PokitToolbarButton(.icon(.kebab), action: { send(.categoryKebobButtonTapped(.포킷삭제, selectedItem: nil)) })
+                PokitToolbarButton(
+                    .icon(.kebab),
+                    action: { send(.카테고리_케밥_버튼_눌렀을때(.포킷삭제, selectedItem: nil)) }
+                )
             }
         }
         .padding(.top, 8)
@@ -102,7 +105,7 @@ private extension CategoryDetailView {
         VStack(spacing: 4) {
             HStack(spacing: 8) {
                 /// cateogry title
-                Button(action: { send(.categorySelectButtonTapped) }) {
+                Button(action: { send(.카테고리_선택_버튼_눌렀을때) }) {
                     Text(store.category.categoryName)
                         .foregroundStyle(.pokit(.text(.primary)))
                         .pokitFont(.title1)
@@ -125,7 +128,7 @@ private extension CategoryDetailView {
                     state: .filled(.primary),
                     size: .small,
                     shape: .round,
-                    action: { send(.filterButtonTapped) }
+                    action: { send(.필터_버튼_눌렀을때) }
                 )
             }
         }
@@ -154,8 +157,8 @@ private extension CategoryDetailView {
                                 
                                 PokitLinkCard(
                                     link: content,
-                                    action: { send(.contentItemTapped(content)) },
-                                    kebabAction: { send(.categoryKebobButtonTapped(.링크삭제, selectedItem: content)) }
+                                    action: { send(.컨텐츠_항목_눌렀을때(content)) },
+                                    kebabAction: { send(.카테고리_케밥_버튼_눌렀을때(.링크삭제, selectedItem: content)) }
                                 )
                                 .divider(isFirst: isFirst, isLast: isLast)
                                 .pokitScrollTransition(.opacity)

--- a/Projects/Feature/FeatureCategoryDetail/Sources/Sheet/CategoryFilterSheet.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/Sheet/CategoryFilterSheet.swift
@@ -66,7 +66,7 @@ private extension CategoryFilterSheet {
                 Spacer()
             }
             .overlay(alignment: .topTrailing) {
-                Button(action: { delegateSend?(.dismissButtonTapped) }) {
+                Button(action: { delegateSend?(.dismiss) }) {
                     Image(.icon(.x))
                 }
                 .buttonStyle(.plain)
@@ -105,7 +105,7 @@ private extension CategoryFilterSheet {
                 "확인",
                 state: .filled(.primary),
                 action: { delegateSend?(
-                    .okButtonTapped(
+                    .확인_버튼_눌렀을때(
                         self.sortType,
                         bookMarkSelected: self.isBookMarkSelected,
                         unReadSelected: self.isUnReadSelected
@@ -174,8 +174,8 @@ private extension CategoryFilterSheet {
 //MARK: - Delegate
 public extension CategoryFilterSheet {
     enum Delegate: Equatable {
-        case dismissButtonTapped
-        case okButtonTapped(SortType, bookMarkSelected: Bool, unReadSelected: Bool)
+        case dismiss
+        case 확인_버튼_눌렀을때(SortType, bookMarkSelected: Bool, unReadSelected: Bool)
     }
 }
 //MARK: - Preview


### PR DESCRIPTION
## #️⃣연관된 이슈

#129

## 📝작업 내용

- 액션 컨벤션에 맞춰 수정
- 일부 순서가 중요하지 않은 Effect 일부 수정
- 열거형 case let 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

```diff
-- case .onAppear:
-- return .run { send in
-- let request = BasePageableRequest(page: 0, size: 30, sort: ["createdAt,desc"])
-- let response = try await categoryClient.카테고리_목록_조회(request, true).toDomain()
-- await send(.async(.카테고리_내_컨텐츠_목록_조회))
-- await send(.inner(.카테고리_목록_조회_결과(response)))

--   for await _ in self.pasteboard.changes() {
--   let url = try await pasteboard.probableWebURL()
--   await send(.delegate(.linkCopyDetected(url)), animation: .pokitSpring)
--   }
--}
++ case .뷰가_나타났을때:
++ return .merge(
++ .send(.async(.카테고리_내_컨텐츠_목록_조회_API)),
++ .send(.async(.카테고리_목록_조회_API)),
++ .send(.async(.클립보드_감지))
++ )
```
예시로 이와 같이 액션으로 분리할 수 있는 것들을 빼낸 후 merge를 통해 가독성을 챙기고
굳이 각기다른 순서가 중요하지 않은 3개의 API들의 await 제거 후 처리되는 순으로 작동하도록 수정하였음
