### PR TITLE
refactor: CategorySettingFeature 액션 수정

### DIFF
--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingFeature.swift
@@ -12,9 +12,6 @@ import Domain
 import CoreKit
 import Util
 
-/// - 사용되는 API 목록
-/// 1. Profile 🎨
-/// 2. 포킷 생성 🖨️
 @Reducer
 public struct PokitCategorySettingFeature {
     /// - Dependency
@@ -148,7 +145,6 @@ public struct PokitCategorySettingFeature {
     public var body: some ReducerOf<Self> {
         BindingReducer(action: \.view)
         Reduce(self.core)
-            ._printChanges()
     }
 }
 //MARK: - FeatureAction Effect
@@ -162,7 +158,6 @@ private extension PokitCategorySettingFeature {
         case .dismiss:
             return .run { _ in await dismiss() }
             
-            /// [Profile 🎨]1. 프로필 목록 조회 API 호출
         case .프로필_설정_버튼_눌렀을때:
             state.isProfileSheetPresented.toggle()
             return .none

--- a/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/PokitCategorySettingView.swift
@@ -45,7 +45,7 @@ public extension PokitCategorySettingView {
                     delegateSend: { store.send(.scope(.profile($0))) }
                 )
             }
-            .task { await send(.onAppear).finish() }
+            .task { await send(.뷰가_나타났을때).finish() }
         }
     }
 }
@@ -101,7 +101,7 @@ private extension PokitCategorySettingView {
                             .foregroundStyle(
                                 .pokit(.icon(.inverseWh))
                             )
-                        Button(action: { send(.profileSettingButtonTapped) }) {
+                        Button(action: { send(.프로필_설정_버튼_눌렀을때) }) {
                             Image(.icon(.edit))
                                 .resizable()
                                 .frame(width: 18, height: 18)
@@ -166,7 +166,7 @@ private extension PokitCategorySettingView {
             state: !store.categoryName.isEmpty && store.selectedProfile != nil
             ? .filled(.primary)
             : .disable,
-            action: { send(.saveButtonTapped) }
+            action: { send(.저장_버튼_눌렀을때) }
         )
     }
     /// 내포킷 Item

--- a/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
+++ b/Projects/Feature/FeatureCategorySetting/Sources/Sheet/ProfileBottomSheet.swift
@@ -45,7 +45,7 @@ public extension ProfileBottomSheet {
                         transaction: .init(animation: .pokitDissolve)
                     ) { phase in
                         if let image = phase.image {
-                            Button(action: { delegateSend?(.imageSelected(item)) }) {
+                            Button(action: { delegateSend?(.이미지_선택했을때(item)) }) {
                                 image
                                     .resizable()
                                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
@@ -91,7 +91,7 @@ public extension ProfileBottomSheet {
 //MARK: - Delegate
 public extension ProfileBottomSheet {
     enum Delegate: Equatable {
-        case imageSelected(BaseCategoryImage)
+        case 이미지_선택했을때(BaseCategoryImage)
     }
 }
 //MARK: - Preview


### PR DESCRIPTION
## #️⃣연관된 이슈

#129

## 📝작업 내용

- 액션 컨벤션에 맞춰 수정
- 프로필 목록, 카테고리 목록 API가 서로 엉켜있어 이를 분리
- 액션으로 가독성을 챙길 수 있는 부분 수정
- 주석들 제거


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

