### PR TITLE
Fix: 인스타그램 등 일부 도메인에서 이미지 조회가 안되는 문제 수정

### DIFF
--- a/Projects/App/ShareExtension/Info.plist
+++ b/Projects/App/ShareExtension/Info.plist
@@ -2,12 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>TeamID</key>
-	<string>$(TeamID)</string>
-	<key>GIDClientID</key>
-	<string>$(GIDClientID)</string>
 	<key>AppleKeyID</key>
 	<string>$(AppleKeyID)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Pokit</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>Pokit</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -19,34 +25,30 @@
 			</array>
 		</dict>
 	</array>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>CFBundleName</key>
-	<string>Pokit</string>
-	<key>CFBundleDisplayName</key>
-	<string>Pokit</string>
+	<key>GIDClientID</key>
+	<string>$(GIDClientID)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
 				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
 				<integer>1000</integer>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1000</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
 			</dict>
 		</dict>
-		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
 	</dict>
+	<key>TeamID</key>
+	<string>$(TeamID)</string>
 </dict>
 </plist>

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -34,7 +34,11 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
     @MainActor
     private var buttonLabel: some View {
         HStack(spacing: 12) {
-            thumbleNail
+            if let url = URL(string: link.thumbNail) {
+                thumbleNail(url: url)
+            } else {
+                placeholder
+            }
             
             VStack(spacing: 8) {
                 HStack {
@@ -105,33 +109,45 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
     }
     
     @MainActor
-    private var thumbleNail: some View {
-        LazyImage(url: .init(string: link.thumbNail)) { phase in
+    private func thumbleNail(url: URL) -> some View {
+        var request = URLRequest(url: url)
+        request.setValue(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+        
+        return LazyImage(request: .init(urlRequest: request)) { phase in
             Group {
                 if let image = phase.image {
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                 } else {
-                    ZStack {
-                        Color.pokit(.bg(.disable))
-                        
-                        PokitSpinner()
-                            .foregroundStyle(.pokit(.icon(.brand)))
-                            .frame(width: 48, height: 48)
-                    }
+                    placeholder
                 }
             }
             .animation(.pokitDissolve, value: phase.image)
+            .frame(width: 124, height: 94)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
-        .frame(width: 124, height: 94)
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
     
     private var divider: some View {
         Rectangle()
             .fill(.pokit(.color(.grayScale(._100))))
             .frame(height: 1)
+    }
+    
+    private var placeholder: some View {
+        ZStack {
+            Color.pokit(.bg(.disable))
+            
+            PokitSpinner()
+                .foregroundStyle(.pokit(.icon(.brand)))
+                .frame(width: 48, height: 48)
+        }
+        .frame(width: 124, height: 94)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
     
     @ViewBuilder

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -137,25 +137,15 @@ extension RemindView {
         Button(action: { send(.컨텐츠_항목_눌렀을때(content: content)) }) {
             recommendedContentCellLabel(content: content)
         }
-        
     }
     
     @ViewBuilder
     private func recommendedContentCellLabel(content: BaseContentItem) -> some View {
         ZStack(alignment: .bottom) {
-            LazyImage(url: .init(string: content.thumbNail)) { phase in
-                if let image = phase.image {
-                    image
-                        .resizable()
-                } else {
-                    ZStack {
-                        Color.pokit(.bg(.disable))
-                        
-                        PokitSpinner()
-                            .foregroundStyle(.pokit(.icon(.brand)))
-                            .frame(width: 48, height: 48)
-                    }
-                }
+            if let url = URL(string: content.thumbNail) {
+                recommendedContentCellImage(url: url)
+            } else {
+                imagePlaceholder
             }
             
             LinearGradient(
@@ -203,6 +193,34 @@ extension RemindView {
         }
         .frame(width: 216, height: 194)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+    
+    @MainActor
+    private func recommendedContentCellImage(url: URL) -> some View {
+        var request = URLRequest(url: url)
+        request.setValue(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
+            forHTTPHeaderField: "User-Agent"
+        )
+        
+        return LazyImage(request: .init(urlRequest: request)) { phase in
+            if let image = phase.image {
+                image
+                    .resizable()
+            } else {
+                imagePlaceholder
+            }
+        }
+    }
+    
+    private var imagePlaceholder: some View {
+        ZStack {
+            Color.pokit(.bg(.disable))
+            
+            PokitSpinner()
+                .foregroundStyle(.pink)
+                .frame(width: 48, height: 48)
+        }
     }
     
     @ViewBuilder


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#152 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 인스타그램 도메인을 가진 url에서 이미지 조회가 안되는 문제를 수정하였습니다.
+++++++++++++++++++++++
- App과 Share Extension의 버전을 맞췄습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
### 인스타그램 도메인을 가진 url에서 이미지 조회가 안되는 문제를 수정하였습니다.
- 저희는 `Nuke`를 쓰고 있기 때문에, 뷰 단에서 `User-Agent` 헤더 값을 가진 요청을 만들어 `LazyImage`에 주입시켰습니다.
```Swift
@MainActor
private func thumbleNail(url: URL) -> some View {
    var request = URLRequest(url: url)
    request.setValue(
        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
        forHTTPHeaderField: "User-Agent"
    )
    
    return LazyImage(request: .init(urlRequest: request)) { phase in
        Group {
            if let image = phase.image {
                image
                    .resizable()
                    .aspectRatio(contentMode: .fill)
            } else {
                placeholder
            }
        }
...
```
- 이렇게 `User-Agent`를 설정하게 되면, 해당 서비스에서 일반적인 브라우저(사파리, 크롬 등)에서 요청하는 것으로 인식해서 조회가 된다고 합니다.
- `User-Agent`를 설정하면 인스타그램은 되지만, 유튜브가 안되는 문제가 있었는데(`SwiftSoupClinet` 작업 당시) 지금은 문제 없이 되고 있는거 같아 일단 이렇게 수정하고, 외부 베타를 통해 지켜볼 예정입니다.

### 추가적으로 `App`과 `Share Extension`의 버전을 급히 맞췄습니다
- 이거 안맞추면 심사 거절 날 수 도 있다고 해서... 이번 이슈는 아니지만 급하게 추가하였습니다..🙏

close #152 
