### PR TITLE
Fix: UI 피드백 반영

### DIFF
--- a/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
@@ -51,13 +51,13 @@ public struct PokitLinkPreview: View {
                 .animation(.pokitDissolve, value: phase.image)
             }
             .frame(width: 124, height: 108)
+            .clipped()
             
             info(title: title)
             
             Spacer()
         }
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .clipped()
         .background {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(.pokit(.bg(.base)))

--- a/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
@@ -31,7 +31,7 @@ public extension PokitAlertBoxView {
                         VStack {
                             PokitCaution(
                                 image: .pooki,
-                                titleKey: "알람이 없어요",
+                                titleKey: "알림이 없어요",
                                 message: "리마인드 알림을 설정하세요"
                             )
                             .padding(.top, 84)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#158 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- `PokitAlertBoxView`의 알림 목록 empty의 UX 워딩을 수정하였습니다.
- `PokitLinkPreview`에서 기본 이미지가 영역을 벗어나는 현상을 수정하였습니다.

### 스크린샷 (선택)

![Simulator Screenshot - iPhone 16 Pro - 2024-11-19 at 16 29 57](https://github.com/user-attachments/assets/dc2300a5-c429-498e-945a-c04d183f324d) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-19 at 16 30 37](https://github.com/user-attachments/assets/474be168-78dd-4e2c-ac7f-78b0ad1e0630)
--- | ---


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 이거 머지하고 바로 1.0.4 릴리즈 할 예정입니다

![image](https://github.com/user-attachments/assets/d4fb8e32-c261-4ace-ace1-7bd95df8b85f)
- UI 점검하다가 발견했는데.. 포킷 목록이 살짝 위쪽으로 짤린거 같은데 원인을 모르겠어요...


close #158 
