### PR TITLE
fix: 1.0.5 버전에 따른 UI 수정 및 기능 추가

### DIFF
--- a/Projects/App/Resources/Pokit-info.plist
+++ b/Projects/App/Resources/Pokit-info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -90,7 +90,8 @@ public extension MainTabFeature {
 
             /// - 포킷 `추가` 버튼 눌렀을 때
             case .delegate(.포킷추가하기),
-                 .path(.element(_, action: .링크추가및수정(.delegate(.포킷추가하기)))):
+                 .path(.element(_, action: .링크추가및수정(.delegate(.포킷추가하기)))),
+                 .pokit(.delegate(.포킷추가_버튼_눌렀을때)):
                 state.path.append(.포킷추가및수정(PokitCategorySettingFeature.State(type: .추가)))
                 return .none
 
@@ -164,7 +165,8 @@ public extension MainTabFeature {
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(contentId: id)))
                 return .none
             /// - 링크 추가하기
-            case .delegate(.링크추가하기):
+            case .delegate(.링크추가하기),
+                 .pokit(.delegate(.링크추가_버튼_눌렀을때)):
                 state.categoryId = nil
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(urlText: state.link)))
                 state.link = nil

--- a/Projects/DSKit/Sources/Components/PokitCaution.swift
+++ b/Projects/DSKit/Sources/Components/PokitCaution.swift
@@ -7,6 +7,70 @@
 
 import SwiftUI
 
+public enum CautionType {
+    case 카테고리없음
+    case 미분류_링크없음
+    case 링크없음
+    case 즐겨찾기_링크없음
+    case 링크부족
+    case 알림없음
+    
+    var image: PokitImage.Character {
+        switch self {
+        case .카테고리없음, .링크없음, .즐겨찾기_링크없음, .미분류_링크없음:
+            return .empty
+        case .링크부족:
+            return .sad
+        case .알림없음:
+            return .pooki
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .카테고리없음:
+            return "저장된 포킷이 없어요!"
+        case .미분류_링크없음:
+            return "미분류 링크가 없어요!"
+        case .링크없음:
+            return "저장된 링크가 없어요!"
+        case .즐겨찾기_링크없음:
+            return "즐겨찾기 링크가 없어요!"
+        case .링크부족:
+            return "링크가 부족해요!"
+        case .알림없음:
+            return "알림이 없어요"
+        }
+    }
+    
+    var message: String {
+        switch self {
+        case .카테고리없음:
+            return "포킷을 생성해 링크를 저장해보세요"
+        case .미분류_링크없음:
+            return "링크를 포킷에 깔끔하게 분류하셨어요"
+        case .링크없음:
+            return "다양한 링크를 한 곳에 저장해보세요"
+        case .즐겨찾기_링크없음:
+            return "링크를 즐겨찾기로 관리해보세요"
+        case .링크부족:
+            return "링크를 5개 이상 저장하고 추천을 받아보세요"
+        case .알림없음:
+            return "리마인드 알림을 설정하세요"
+        }
+    }
+    
+    var actionTitle: String? {
+        switch self {
+        case .카테고리없음:
+            return "포킷 추가하기"
+        case .미분류_링크없음:
+            return "링크 추가하기"
+        default: return nil
+        }
+    }
+}
+
 public struct PokitCaution: View {
     private let image: PokitImage.Character
     private let titleKey: String

--- a/Projects/DSKit/Sources/Components/PokitCaution.swift
+++ b/Projects/DSKit/Sources/Components/PokitCaution.swift
@@ -72,20 +72,14 @@ public enum CautionType {
 }
 
 public struct PokitCaution: View {
-    private let image: PokitImage.Character
-    private let titleKey: String
-    private let message: String
+    private let type: CautionType
     private let action: (() -> Void)?
     
     public init(
-        image: PokitImage.Character,
-        titleKey: String,
-        message: String,
+        type: CautionType,
         action: (() -> Void)? = nil
     ) {
-        self.image = image
-        self.titleKey = titleKey
-        self.message = message
+        self.type = type
         self.action = action
     }
     
@@ -94,27 +88,28 @@ public struct PokitCaution: View {
             Spacer()
             
             VStack(spacing: 0) {
-                Image(.character(image))
+                Image(.character(type.image))
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 180, height: 180)
                     .padding(.bottom, 16)
                 
-                Text(titleKey)
+                Text(type.title)
                     .pokitFont(.title2)
                     .foregroundStyle(.pokit(.text(.secondary)))
                     .padding(.bottom, 8)
                 
-                Text(message)
+                Text(type.message)
                     .pokitFont(.b2(.m))
                     .foregroundStyle(.pokit(.text(.secondary)))
                     .padding(.bottom, 16)
                 
-                if let action {
+                if let action,
+                   let actionTitle = type.actionTitle {
                     PokitTextButton(
-                        "다시시도",
-                        state: .default(.secondary),
-                        size: .small,
+                        actionTitle,
+                        state: .stroke(.secondary),
+                        size: .medium,
                         shape: .rectangle,
                         action: action
                     )
@@ -128,9 +123,7 @@ public struct PokitCaution: View {
 
 #Preview {
     PokitCaution(
-        image: .empty,
-        titleKey: "저장된 포킷이 없어요!",
-        message: "포킷을 생성해 링크를 저장해보세요",
+        type: .미분류_링크없음,
         action: {}
     )
 }

--- a/Projects/DSKit/Sources/Components/PokitList.swift
+++ b/Projects/DSKit/Sources/Components/PokitList.swift
@@ -30,11 +30,7 @@ public struct PokitList<Item: PokitSelectItem>: View {
     public var body: some View {
         if list.isEmpty {
             VStack {
-                PokitCaution(
-                    image: .empty,
-                    titleKey: "저장된 포킷이 없어요!",
-                    message: "포킷을 생성해 링크를 저장해보세요"
-                )
+                PokitCaution(type: .카테고리없음)
                 
                 Spacer()
             }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -140,11 +140,7 @@ private extension CategoryDetailView {
             if !store.isLoading {
                 if store.contents.isEmpty {
                     VStack {
-                        PokitCaution(
-                            image: .empty,
-                            titleKey: "저장된 링크가 없어요!",
-                            message: "다양한 링크를 한 곳에 저장해보세요"
-                        )
+                        PokitCaution(type: .링크없음)
                         .padding(.top, 20)
                         
                         Spacer()

--- a/Projects/Feature/FeatureCategorySharing/Sources/CategorySharing/CategorySharingView.swift
+++ b/Projects/Feature/FeatureCategorySharing/Sources/CategorySharing/CategorySharingView.swift
@@ -91,11 +91,7 @@ private extension CategorySharingView {
             if !store.isLoading {
                 if store.contents.isEmpty {
                     VStack {
-                        PokitCaution(
-                            image: .empty,
-                            titleKey: "저장된 링크가 없어요!",
-                            message: "다양한 링크를 한 곳에 저장해보세요"
-                        )
+                        PokitCaution(type: .링크없음)
                         .padding(.top, 20)
                         
                         Spacer()

--- a/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
+++ b/Projects/Feature/FeatureContentList/Sources/ContentList/ContentListView.swift
@@ -89,11 +89,7 @@ private extension ContentListView {
         Group {
             if !store.isLoading {
                 if store.contents.isEmpty {
-                    PokitCaution(
-                        image: .empty,
-                        titleKey: "즐겨찾기 링크가 없어요!",
-                        message: "링크를 즐겨찾기로 관리해보세요"
-                    )
+                    PokitCaution(type: .즐겨찾기_링크없음)
                     .padding(.top, 100)
                     
                     Spacer()

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -72,6 +72,8 @@ public struct PokitRootFeature {
             case 분류_버튼_눌렀을때
             case 케밥_버튼_눌렀을때(BaseCategoryItem)
             case 미분류_케밥_버튼_눌렀을때(BaseContentItem)
+            case 포킷추가_버튼_눌렀을때
+            case 링크추가_버튼_눌렀을때
             case 카테고리_눌렀을때(BaseCategoryItem)
             case 컨텐츠_항목_눌렀을때(BaseContentItem)
             case 링크_공유_완료되었을때
@@ -123,6 +125,9 @@ public struct PokitRootFeature {
             /// 링크상세로 이동
             case contentDetailTapped(BaseContentItem)
             case 미분류_카테고리_컨텐츠_조회
+            
+            case 포킷추가_버튼_눌렀을때
+            case 링크추가_버튼_눌렀을때
         }
     }
 
@@ -209,6 +214,12 @@ private extension PokitRootFeature {
         case .미분류_케밥_버튼_눌렀을때(let selectedItem):
             state.selectedUnclassifiedItem = selectedItem
             return .run { send in await send(.inner(.카테고리_시트_활성화(true))) }
+            
+        case .포킷추가_버튼_눌렀을때:
+            return .run { send in await send(.delegate(.포킷추가_버튼_눌렀을때)) }
+            
+        case .링크추가_버튼_눌렀을때:
+            return .run { send in await send(.delegate(.링크추가_버튼_눌렀을때)) }
 
         case .카테고리_눌렀을때(let category):
             return .run { send in await send(.delegate(.categoryTapped(category))) }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -126,6 +126,7 @@ private extension PokitRootView {
                     VStack {
                         PokitCaution(
                             type: .카테고리없음,
+                            action: { send(.포킷추가_버튼_눌렀을때) }
                         )
                         .padding(.top, 36)
 
@@ -170,6 +171,7 @@ private extension PokitRootView {
                     VStack {
                         PokitCaution(
                             type: .미분류_링크없음,
+                            action: { send(.링크추가_버튼_눌렀을때) }
                         )
                         .padding(.top, 36)
 

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -125,9 +125,7 @@ private extension PokitRootView {
                 if categories.isEmpty {
                     VStack {
                         PokitCaution(
-                            image: .empty,
-                            titleKey: "저장된 포킷이 없어요!",
-                            message: "포킷을 생성해 링크를 저장해보세요"
+                            type: .카테고리없음,
                         )
                         .padding(.top, 36)
 
@@ -171,9 +169,7 @@ private extension PokitRootView {
                 if store.contents.isEmpty {
                     VStack {
                         PokitCaution(
-                            image: .empty,
-                            titleKey: "저장된 링크가 없어요!",
-                            message: "다양한 링크를 한 곳에 저장해보세요"
+                            type: .미분류_링크없음,
                         )
                         .padding(.top, 36)
 

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindView.swift
@@ -68,11 +68,7 @@ extension RemindView {
                    unreadContents.isEmpty &&
                    favoriteContents.isEmpty {
                     VStack {
-                        PokitCaution(
-                            image: .sad,
-                            titleKey: "링크가 부족해요!",
-                            message: "링크를 5개 이상 저장하고 추천을 받아보세요"
-                        )
+                        PokitCaution(type: .링크부족)
                         .padding(.top, 100)
                         
                         Spacer()
@@ -111,11 +107,7 @@ extension RemindView {
                 .padding(.horizontal, 20)
             
             if recommendedContents.isEmpty {
-                PokitCaution(
-                    image: .sad,
-                    titleKey: "링크가 부족해요!",
-                    message: "링크를 5개 이상 저장하고 추천을 받아보세요"
-                )
+                PokitCaution(type: .링크부족)
                 .padding(.top, 24)
                 .padding(.bottom, 32)
             } else {
@@ -293,11 +285,7 @@ extension RemindView {
             .padding(.bottom, 16)
             
             if favoriteContents.isEmpty {
-                PokitCaution(
-                    image: .empty,
-                    titleKey: "즐겨찾기 링크가 없어요!",
-                    message: "링크를 즐겨찾기로 관리해보세요"
-                )
+                PokitCaution(type: .즐겨찾기_링크없음)
                 .padding(.top, 16)
             } else {
                 ForEach(favoriteContents, id: \.id) { content in

--- a/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxView.swift
@@ -29,11 +29,7 @@ public extension PokitAlertBoxView {
                 if let alertContents = store.alertContents {
                     if alertContents.isEmpty {
                         VStack {
-                            PokitCaution(
-                                image: .pooki,
-                                titleKey: "알림이 없어요",
-                                message: "리마인드 알림을 설정하세요"
-                            )
+                            PokitCaution(type: .알림없음)
                             .padding(.top, 84)
                             Spacer()
                         }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchView.swift
@@ -89,6 +89,7 @@ private extension PokitSearchView {
             PokitIconRInput(
                 text: $store.searchText,
                 icon: store.isSearching ? .icon(.x) : .icon(.search),
+                placeholder: "제목, 메모를 검색해보세요.",
                 shape: .round,
                 focusState: $focused,
                 equals: true,


### PR DESCRIPTION
## #️⃣연관된 이슈

#156 

## 📝작업 내용

- Empty / Error 화면인 PokitCaution 내부 프로퍼티를 열거형으로 합쳤습니다. 이곳저곳에서 하드코딩된 string값이 사용되고 있기에 유지보수 차원에서 이번 작업과 함께 수정했습니다.
- empty 시 카테고리추가 / 링크추가 액션들의 화면이동 로직을 연결했습니다.
- 검색바 placeholder 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
포킷추가, 링크추가 버튼이 기존에 디자인시스템과 살짝 다른 것 같습니다. 
hPadding이 16이던데 현재 적용한 수치는 작성해주신 버튼의 열거형을 토대로 작업해서 피그마 상 수치와 다릅니다. 디자이너분들과 상의필요..

close #156 
