### PR TITLE
feat: 1.0.6베타 QA 반영

### DIFF
--- a/Projects/App/ShareExtension/Sources/ShareRootFeature.swift
+++ b/Projects/App/ShareExtension/Sources/ShareRootFeature.swift
@@ -106,10 +106,10 @@ struct ShareRootFeature {
     func handleAsyncAction(_ action: Action.AsyncAction, state: inout State) -> Effect<Action> {
         switch action {
         case .URL_파싱_수행:
-            guard let item = state.context?.inputItems.first as? NSExtensionItem,
-                  let itemProvider = item.attachments?.first else {
-                return .none
-            }
+            guard
+                let item = state.context?.inputItems.first as? NSExtensionItem,
+                let itemProvider = item.attachments?.first
+            else { return .none }
             
             return .run { send in
                 var urlItem: (any NSSecureCoding)? = nil

--- a/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
+++ b/Projects/App/Sources/AppDelegate/AppDelegateFeature.swift
@@ -60,7 +60,8 @@ public struct AppDelegateFeature {
                             let setting = await self.userNotifications.getNotificationSettings()
                             switch setting.authorizationStatus {
                             case .authorized, .notDetermined:
-                                guard try await self.userNotifications.requestAuthorization([.alert, .sound])
+                                guard
+                                    try await self.userNotifications.requestAuthorization([.alert, .sound])
                                 else { return }
                             default: return
                             }

--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -41,7 +41,7 @@ public struct MainTabFeature {
         @Presents var contentDetail: ContentDetailFeature.State?
         @Shared(.inMemory("SelectCategory")) var categoryId: Int?
         @Shared(.inMemory("PushTapped")) var isPushTapped: Bool = false
-        var savedContentId: Int?
+        var categoryOfSavedContent: BaseCategoryItem?
 
         public init() {
             self.pokit = .init()
@@ -78,6 +78,7 @@ public struct MainTabFeature {
             case 경고_띄움(BaseError)
             case errorSheetPresented(Bool)
             case 링크팝업_활성화(PokitLinkPopup.PopupType)
+            case 카테고리상세_이동(category: BaseCategoryItem)
         }
         public enum AsyncAction: Equatable {
             case 공유받은_카테고리_조회(categoryId: Int)
@@ -98,7 +99,7 @@ public struct MainTabFeature {
         switch action {
         case .binding(\.linkPopup):
             guard state.linkPopup == nil else { return .none }
-            state.savedContentId = nil
+            state.categoryOfSavedContent = nil
             return .none
         case .binding:
             return .none
@@ -222,7 +223,14 @@ private extension MainTabFeature {
         case let .링크팝업_활성화(type):
             state.linkPopup = type
             return .none
-
+        case let .카테고리상세_이동(category):
+            if category.categoryName == "미분류" {
+                state.selectedTab = .pokit
+                state.path.removeAll()
+                return .send(.pokit(.delegate(.미분류_카테고리_활성화)))
+            }
+            state.path.append(.카테고리상세(.init(category: category)))
+            return .none
         default: return .none
         }
     }
@@ -259,9 +267,9 @@ private extension MainTabFeature {
             return .send(.delegate(.링크추가하기))
         case .success:
             state.linkPopup = nil
-            state.contentDetail = .init(contentId: state.savedContentId)
-            state.savedContentId = nil
-            return .none
+            guard let category = state.categoryOfSavedContent else { return .none }
+            state.categoryOfSavedContent = nil
+            return .send(.inner(.카테고리상세_이동(category: category)))
         case .error, .text, .warning, .none:
             return .none
         }

--- a/Projects/App/Sources/MainTab/MainTabFeature.swift
+++ b/Projects/App/Sources/MainTab/MainTabFeature.swift
@@ -184,15 +184,15 @@ private extension MainTabFeature {
                 }
             )
         case .onOpenURL(url: let url):
-            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                return .none
-            }
+            guard
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            else { return .none }
 
             let queryItems = components.queryItems ?? []
-            guard let categoryIdString = queryItems.first(where: { $0.name == "categoryId" })?.value,
-                  let categoryId = Int(categoryIdString) else {
-                return .none
-            }
+            guard
+                let categoryIdString = queryItems.first(where: { $0.name == "categoryId" })?.value,
+                let categoryId = Int(categoryIdString)
+            else { return .none }
 
             return .send(.async(.공유받은_카테고리_조회(categoryId: categoryId)))
         case .경고_확인버튼_클릭:

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -175,7 +175,7 @@ public extension MainTabFeature {
 
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
             case let .path(.element(stackElementId, action: .링크추가및수정(.delegate(.저장하기_완료(contentId))))):
-                state.savedContentId = contentId
+                state.categoryOfSavedContent = contentId
                 state.path.removeLast()
                 switch state.path.last {
                 case .검색:

--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -141,8 +141,10 @@ public extension MainTabFeature {
             case .contentDetail(.presented(.delegate(.즐겨찾기_갱신_완료))),
                  .contentDetail(.presented(.delegate(.컨텐츠_조회_완료))),
                  .contentDetail(.presented(.delegate(.컨텐츠_삭제_완료))):
-                guard let stackElementId = state.path.ids.last,
-                      let lastPath = state.path.last else {
+                guard
+                    let stackElementId = state.path.ids.last,
+                    let lastPath = state.path.last
+                else {
                     switch state.selectedTab {
                     case .pokit:
                         return .send(.pokit(.delegate(.미분류_카테고리_컨텐츠_조회)))

--- a/Projects/CoreKit/Sources/CoreNetwork/TokenInterceptor.swift
+++ b/Projects/CoreKit/Sources/CoreNetwork/TokenInterceptor.swift
@@ -44,16 +44,20 @@ public final class TokenInterceptor: RequestInterceptor {
         dueTo error: Error,
         completion: @escaping (RetryResult) -> Void
     ) {
-        guard let response = request.task?.response as? HTTPURLResponse,
-              response.statusCode == 401 else {
+        guard
+            let response = request.task?.response as? HTTPURLResponse,
+            response.statusCode == 401
+        else {
             completion(.doNotRetryWithError(error))
             return
         }
 
         print("🚀 Retry: statusCode: \(response.statusCode)")
 
-        guard keychain.read(.accessToken) != nil,
-              let refreshToken = keychain.read(.refreshToken) else {
+        guard
+            keychain.read(.accessToken) != nil,
+            let refreshToken = keychain.read(.refreshToken)
+        else {
             deleteAllToken()
             completion(.doNotRetryWithError(error))
             return

--- a/Projects/CoreKit/Sources/Data/Client/KakaoSDK/Share/KakaoShareClient+LiveKey.swift
+++ b/Projects/CoreKit/Sources/Data/Client/KakaoSDK/Share/KakaoShareClient+LiveKey.swift
@@ -45,14 +45,16 @@ extension KakaoShareClient: DependencyKey {
                     buttons: [button]
                 )
                 
-                guard ShareApi.isKakaoTalkSharingAvailable(),
-                      let templateJsonData = try? SdkJSONEncoder.custom.encode(template),
-                      let templateJsonObject = SdkUtils.toJsonObject(templateJsonData) else {
+                guard
+                    ShareApi.isKakaoTalkSharingAvailable(),
+                    let templateJsonData = try? SdkJSONEncoder.custom.encode(template),
+                    let templateJsonObject = SdkUtils.toJsonObject(templateJsonData)
+                else {
                     /// 🚨 Error Case [1]: 카카오톡 미설치
-                    guard let url = URL(string: "itms-apps://itunes.apple.com/app/id362057947"),
-                          UIApplication.shared.canOpenURL(url) else {
-                        return
-                    }
+                    guard
+                        let url = URL(string: "itms-apps://itunes.apple.com/app/id362057947"),
+                        UIApplication.shared.canOpenURL(url)
+                    else { return }
                     
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     return

--- a/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/AppleLoginController.swift
+++ b/Projects/CoreKit/Sources/Data/Client/SocialLogin/Controller/AppleLoginController.swift
@@ -33,22 +33,28 @@ public final class AppleLoginController: NSObject, ASAuthorizationControllerDele
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
-        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+        guard
+            let credential = authorization.credential as? ASAuthorizationAppleIDCredential
+        else {
             continuation?.resume(throwing: SocialLoginError.invalidCredential)
             continuation = nil
             return
         }
         
         
-        guard let tokenData = credential.identityToken,
-              let token = String(data: tokenData, encoding: .utf8) else {
+        guard
+            let tokenData = credential.identityToken,
+            let token = String(data: tokenData, encoding: .utf8)
+        else {
             continuation?.resume(throwing: SocialLoginError.appleLoginError(.invalidIdentityToken))
             continuation = nil
             return
         }
         
-        guard let authorizationCode = credential.authorizationCode,
-              let codeString = String(data: authorizationCode, encoding: .utf8) else {
+        guard
+            let authorizationCode = credential.authorizationCode,
+            let codeString = String(data: authorizationCode, encoding: .utf8)
+        else {
             continuation?.resume(throwing: SocialLoginError.appleLoginError(.invalidAuthorizationCode))
             continuation = nil
             return

--- a/Projects/DSKit/Sources/Components/PokitBadge.swift
+++ b/Projects/DSKit/Sources/Components/PokitBadge.swift
@@ -19,12 +19,6 @@ public struct PokitBadge: View {
             .background {
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
                     .fill(backgroundColor)
-                    .overlay {
-                        if state == .unRead {
-                            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                                .stroke(.pokit(.border(.brand)), lineWidth: 1)
-                        }
-                    }
             }
     }
     
@@ -32,7 +26,7 @@ public struct PokitBadge: View {
         switch self.state {
         case .default, .small, .memo, .member: return .pokit(.bg(.primary))
         case .unCategorized: return .pokit(.color(.grayScale(._50)))
-        case .unRead: return .pokit(.bg(.base))
+        case .unRead: return Color(red: 1, green: 0.95, blue: 0.92)
         }
     }
     

--- a/Projects/DSKit/Sources/Components/PokitCalendar.swift
+++ b/Projects/DSKit/Sources/Components/PokitCalendar.swift
@@ -208,13 +208,13 @@ public struct PokitCalendar: View {
             let year = calendar.component(.year, from: date)
             let month = calendar.component(.month, from: date)
             
-            guard let range = calendar.range(
-                of: .day,
-                in: .month,
-                for: date
-            ) else {
-                return dates
-            }
+            guard
+                let range = calendar.range(
+                    of: .day,
+                    in: .month,
+                    for: date
+                )
+            else { return dates }
             
             dates = range.map { day in
                 var components = DateComponents()
@@ -255,13 +255,13 @@ public struct PokitCalendar: View {
                 return dates
             }
             
-            guard let monthRange = calendar.range(
-                of: .day,
-                in: .month,
-                for: monthDate
-            ) else {
-                return dates
-            }
+            guard
+                let monthRange = calendar.range(
+                    of: .day,
+                    in: .month,
+                    for: monthDate
+                )
+            else { return dates }
             
             let monthDays = Array(monthRange).suffix(firstWeekday - 1)
             
@@ -369,25 +369,24 @@ public struct PokitCalendar: View {
     }
     
     private func beforeButtonTapped() {
-        guard let date = calendar.date(
-            byAdding: .month,
-            value: -1,
-            to: currentDate
-        ) else {
-            return
-        }
+        guard
+            let date = calendar.date(
+                byAdding: .month,
+                value: -1,
+                to: currentDate
+            ) else { return }
         
         self.page = formatter.string(from: date)
     }
     
     private func nextButtonTapped() {
-        guard let date = calendar.date(
-            byAdding: .month,
-            value: 1,
-            to: currentDate
-        ) else {
-            return
-        }
+        guard
+            let date = calendar.date(
+                byAdding: .month,
+                value: 1,
+                to: currentDate
+            )
+        else { return }
         
         self.page = formatter.string(from: date)
     }

--- a/Projects/DSKit/Sources/Components/PokitLinkCard.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkCard.swift
@@ -135,15 +135,15 @@ public struct PokitLinkCard<Item: PokitLinkCardItem>: View {
         let isUnCategorized = link.categoryName == "미분류"
         
         HStack(spacing: 6) {
-            if let isRead = link.isRead, !isRead {
-                PokitBadge(state: .unRead)
-            }
-            
             PokitBadge(
                 state: isUnCategorized
                 ? .unCategorized
                 : .default(link.categoryName)
             )
+            
+            if let isRead = link.isRead, !isRead {
+                PokitBadge(state: .unRead)
+            }
             
             if let memo = link.memo, !memo.isEmpty {
                 PokitBadge(state: .memo)

--- a/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import Util
 import NukeUI
 
 public struct PokitLinkPreview: View {
@@ -33,7 +34,6 @@ public struct PokitLinkPreview: View {
         }
     }
     
-
     private var buttonLabel: some View {
         HStack(spacing: 16) {
             Group {
@@ -54,18 +54,13 @@ public struct PokitLinkPreview: View {
         .background {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(.pokit(.bg(.base)))
+                .shadow(color: .black.opacity(0.06), radius: 3, x: 2, y: 2)
         }
         .overlay {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(.pokit(.border(.tertiary)), lineWidth: 1)
         }
-        .shadow(color: .black.opacity(0.06), radius: 3, x: 2, y: 2)
-        .onAppear {
-            withAnimation {
-                UINotificationFeedbackGenerator()
-                    .notificationOccurred(.success)
-            }
-        }
+        .onChange(of: imageURL, perform: onChangeImageURL)
     }
     
     @MainActor
@@ -133,6 +128,14 @@ public struct PokitLinkPreview: View {
             let url = URL(string: urlString)
         else { return }
         openURL(url)
+    }
+    
+    private func onChangeImageURL(_ imageURL: String?) {
+        guard imageURL != nil else { return }
+        let isError = title == Constants.제목을_입력해주세요_문구
+        print("\(#function): \(isError), \(title)")
+        UINotificationFeedbackGenerator()
+            .notificationOccurred(isError ? .error : .success)
     }
 }
 

--- a/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
+++ b/Projects/DSKit/Sources/Components/PokitLinkPreview.swift
@@ -133,7 +133,6 @@ public struct PokitLinkPreview: View {
     private func onChangeImageURL(_ imageURL: String?) {
         guard imageURL != nil else { return }
         let isError = title == Constants.제목을_입력해주세요_문구
-        print("\(#function): \(isError), \(title)")
         UINotificationFeedbackGenerator()
             .notificationOccurred(isError ? .error : .success)
     }

--- a/Projects/DSKit/Sources/Components/PokitList.swift
+++ b/Projects/DSKit/Sources/Components/PokitList.swift
@@ -81,7 +81,7 @@ public struct PokitList<Item: PokitSelectItem>: View {
                 
                 Spacer()
             }
-            .padding(.vertical, 18)
+            .padding(.vertical, 12)
             .padding(.horizontal, 20)
             .background {
                 if isSelected {

--- a/Projects/DSKit/Sources/Components/PokitListButton.swift
+++ b/Projects/DSKit/Sources/Components/PokitListButton.swift
@@ -38,7 +38,7 @@ public struct PokitListButton: View {
             HStack {
                 switch type {
                 case let .default(icon, iconColor),
-                    let .bottomSheet(icon, iconColor),
+                    let .bottomSheet(icon, iconColor, _),
                     let .subText(icon, iconColor, _):
                     Text(title)
                         .pokitFont(.b1(.m))
@@ -76,9 +76,9 @@ public struct PokitListButton: View {
             }
         }
         .padding(.horizontal, 24)
-        .padding(.vertical, 16)
+        .padding(.vertical, 20)
         .background(alignment: .bottom) {
-            if case .bottomSheet = type {
+            if case let .bottomSheet(_, _, isLast) = type, !isLast {
                 Rectangle()
                     .fill(.pokit(.border(.tertiary)))
                     .frame(height: 1)
@@ -90,10 +90,9 @@ public struct PokitListButton: View {
 extension PokitListButton {
     public enum ListButtonType {
         case `default`(icon: PokitImage, iconColor: Color)
-        case bottomSheet(icon: PokitImage, iconColor: Color)
+        case bottomSheet(icon: PokitImage, iconColor: Color, isLast: Bool = false)
         case subText(icon: PokitImage, iconColor: Color, subeText: String)
         case toggle(subeText: String)
-        
     }
 }
 

--- a/Projects/DSKit/Sources/Components/PokitSelect.swift
+++ b/Projects/DSKit/Sources/Components/PokitSelect.swift
@@ -50,11 +50,11 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
         }
         .onChange(of: selectedItem) { onChangedSeletedItem($0) }
         .sheet(isPresented: $showSheet) {
-                listSheet
-                    .presentationDragIndicator(.visible)
-                    .pokitPresentationCornerRadius()
-                    .presentationDetents([.height(564)])
-                    .pokitPresentationBackground()
+            listSheet
+                .presentationDragIndicator(.visible)
+                .pokitPresentationCornerRadius()
+                .presentationDetents([.height(564)])
+                .pokitPresentationBackground()
         }
     }
     

--- a/Projects/DSKit/Sources/Components/PokitSelect.swift
+++ b/Projects/DSKit/Sources/Components/PokitSelect.swift
@@ -50,11 +50,11 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
         }
         .onChange(of: selectedItem) { onChangedSeletedItem($0) }
         .sheet(isPresented: $showSheet) {
-            listSheet
-                .presentationDragIndicator(.visible)
-                .pokitPresentationCornerRadius()
-                .presentationDetents([.medium])
-                .pokitPresentationBackground()
+                listSheet
+                    .presentationDragIndicator(.visible)
+                    .pokitPresentationCornerRadius()
+                    .presentationDetents([.height(564)])
+                    .pokitPresentationBackground()
         }
     }
     
@@ -115,7 +115,7 @@ public struct PokitSelect<Item: PokitSelectItem>: View {
                         listCellTapped(item)
                     }
                 }
-                .padding(.top, 24)
+                .padding(.top, 12)
                 .padding(.bottom, 20)
             } else {
                 PokitLoading()

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -225,9 +225,11 @@ private extension CategoryDetailFeature {
             
         case let .카테고리_목록_조회_API_반영(response):
             state.domain.categoryListInQuiry = response
-            guard let first = response.data?.first(where: { item in
-                item.id == state.domain.category.id
-            }) else { return .none }
+            guard
+                let first = response.data?.first(where: { item in
+                    item.id == state.domain.category.id
+                })
+            else { return .none }
             state.domain.category = first
             return .none
             

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -168,10 +168,10 @@ private extension ContentDetailFeature {
         case .binding:
             return .none
         case .즐겨찾기_버튼_눌렀을때:
-            guard let content = state.domain.content,
-                  let favorites = state.domain.content?.favorites else {
-                return .none
-            }
+            guard
+                let content = state.domain.content,
+                let favorites = state.domain.content?.favorites
+            else { return .none }
             return favorites
             ? .send(.async(.즐겨찾기_취소_API(id: content.id)))
             : .send(.async(.즐겨찾기_API(id: content.id)))

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailFeature.swift
@@ -69,10 +69,12 @@ public struct ContentDetailFeature {
             case 삭제_버튼_눌렀을때
             case 삭제확인_버튼_눌렀을때
             case 즐겨찾기_버튼_눌렀을때
+            case 키보드_취소_버튼_눌렀을때
+            case 키보드_완료_버튼_눌렀울때
+            
             case 경고시트_해제
 
             case 링크_공유_완료되었을때
-            case 메모포커스_변경되었을때(Bool)
         }
 
         public enum InnerAction: Equatable {
@@ -179,12 +181,12 @@ private extension ContentDetailFeature {
         case .경고시트_해제:
             state.showAlert = false
             return .none
-        case let .메모포커스_변경되었을때(isFocused):
-            guard
-                !isFocused,
-                state.memo != state.domain.content?.memo
-            else { return .none }
+        case .키보드_취소_버튼_눌렀을때:
+            state.memo = state.domain.content?.memo ?? ""
+            return .none
+        case .키보드_완료_버튼_눌렀울때:
             let memo = state.memo
+            guard memo != state.domain.content?.memo else { return .none }
             state.domain.content?.memo = memo
             return .send(.async(.컨텐츠_수정_API))
         }

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -56,8 +56,8 @@ public extension ContentDetailView {
                     PokitLinkPopup(type: $store.linkPopup)
                 }
             }
-            .dismissKeyboard(focused: $isFocused)
-            .onChange(of: isFocused) { send(.메모포커스_변경되었을때($0)) }
+//            .dismissKeyboard(focused: $isFocused)
+//            .onChange(of: isFocused) { send(.메모포커스_변경되었을때($0)) }
             .sheet(isPresented: $store.showAlert) {
                 PokitAlert(
                     "링크를 정말 삭제하시겠습니까?",
@@ -159,11 +159,28 @@ private extension ContentDetailView {
                 focusState: $isFocused,
                 equals: true
             )
+            .toolbar { keyboardToolBar }
             .frame(minHeight: isFocused ? 164 : 132)
             .animation(.pokitDissolve, value: isFocused)
         }
         .padding(.bottom, 24)
         .padding(.horizontal, 20)
+    }
+    
+    var keyboardToolBar: some ToolbarContent {
+        ToolbarItemGroup(placement: .keyboard) {
+            Button("취소") {
+                isFocused = false
+                send(.키보드_취소_버튼_눌렀을때)
+            }
+            
+            Spacer()
+            
+            Button("완료") {
+                isFocused = false
+                send(.키보드_완료_버튼_눌렀울때)
+            }
+        }
     }
 
     @ViewBuilder

--- a/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
+++ b/Projects/Feature/FeatureContentDetail/Sources/ContentDetail/ContentDetailView.swift
@@ -34,8 +34,9 @@ public extension ContentDetailView {
                         VStack(spacing: 0) {
                             contentMemo
                             
-                            Divider()
+                            Rectangle()
                                 .foregroundStyle(.pokit(.border(.tertiary)))
+                                .frame(height: 1)
                             
                             bottomList(favorites: favorites)
                         }
@@ -56,8 +57,6 @@ public extension ContentDetailView {
                     PokitLinkPopup(type: $store.linkPopup)
                 }
             }
-//            .dismissKeyboard(focused: $isFocused)
-//            .onChange(of: isFocused) { send(.메모포커스_변경되었을때($0)) }
             .sheet(isPresented: $store.showAlert) {
                 PokitAlert(
                     "링크를 정말 삭제하시겠습니까?",
@@ -110,8 +109,6 @@ private extension ContentDetailView {
     func title(content: BaseContentDetail) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Group {
-                remindAndBadge(content: content)
-
                 Text(content.title)
                     .pokitFont(.title3)
                     .foregroundStyle(.pokit(.text(.primary)))
@@ -119,6 +116,8 @@ private extension ContentDetailView {
                     .lineLimit(2)
 
                 HStack {
+                    remindAndBadge(content: content)
+                    
                     Spacer()
 
                     Text(content.createdAt)
@@ -128,8 +127,9 @@ private extension ContentDetailView {
             }
             .padding(.horizontal, 20)
 
-            Divider()
+            Rectangle()
                 .foregroundStyle(.pokit(.border(.tertiary)))
+                .frame(height: 1)
                 .padding(.top, 4)
         }
     }
@@ -221,7 +221,8 @@ private extension ContentDetailView {
                 title: "삭제하기",
                 type: .bottomSheet(
                     icon: .icon(.trash),
-                    iconColor: .pokit(.icon(.primary))
+                    iconColor: .pokit(.icon(.primary)),
+                    isLast: true
                 ),
                 action: { send(.삭제_버튼_눌렀을때) }
             )

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -224,9 +224,10 @@ private extension ContentSettingFeature {
             return .send(.inner(.링크복사_반영(state.link)))
         case .링크지우기_버튼_눌렀을때:
             state.domain.data = ""
+            state.domain.title = ""
             return .none
         case .제목지우기_버튼_눌렀을때:
-            state.title = ""
+            state.domain.title = ""
             return .none
         }
     }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -255,8 +255,8 @@ private extension ContentSettingFeature {
             let contentTitle = state.title.isEmpty
             ? Constants.제목을_입력해주세요_문구
             : state.title
-            state.linkTitle = title ?? contentTitle
             state.linkImageURL = imageURL ?? Constants.기본_썸네일_주소.absoluteString
+            state.linkTitle = title ?? contentTitle
             if let title, state.domain.title.isEmpty {
                 state.domain.title = title
             }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -50,10 +50,6 @@ public struct ContentSettingFeature {
             get { domain.memo }
             set { domain.memo = newValue }
         }
-        var isRemind: BaseContentDetail.RemindState {
-            get { domain.alertYn }
-            set { domain.alertYn = newValue }
-        }
         var content: BaseContentDetail? {
             get { domain.content }
         }

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -263,8 +263,10 @@ private extension ContentSettingFeature {
             state.domain.thumbNail = imageURL
             return .send(.inner(.linkPreview), animation: .pokitDissolve)
         case .URL_유효성_확인:
-            guard let url = URL(string: state.domain.data),
-                  !state.domain.data.isEmpty else {
+            guard
+                let url = URL(string: state.domain.data),
+                !state.domain.data.isEmpty
+            else {
                 /// 🚨 Error Case [1]: 올바른 링크가 아닐 때
                 state.linkPopup = nil
                 state.linkTitle = nil
@@ -309,8 +311,16 @@ private extension ContentSettingFeature {
             /// - `카테고리_목록_조회`의 filter 옵션을 `false`로 해두었기 때문에 `미분류` 카테고리 또한 항목에서 조회가 가능함
 
             /// [1]. `미분류`에 해당하는 인덱스 번호와 항목을 체크, 없다면 목록갱신이 불가함
-            guard let unclassifiedItemIdx = categoryList.data?.firstIndex(where: { $0.categoryName == "미분류" }) else { return .none }
-            guard let unclassifiedItem = categoryList.data?.first(where: { $0.categoryName == "미분류" }) else { return .none }
+            guard
+                let unclassifiedItemIdx = categoryList.data?.firstIndex(where: {
+                    $0.categoryName == "미분류"
+                })
+            else { return .none }
+            guard
+                let unclassifiedItem = categoryList.data?.first(where: {
+                    $0.categoryName == "미분류"
+                })
+            else { return .none }
             
             /// [2]. 새로운 list변수를 만들어주고 카테고리 항목 순서를 재배치 (최신순 정렬 시  미분류는 항상 맨 마지막)
             var list = categoryList

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -40,8 +40,6 @@ public extension ContentSettingView {
                             pokitSelectButton
                             
                             memoTextArea
-                            
-                            remindSwitchRadio
                         }
                         .padding(.horizontal, 20)
                         .padding(.top, 16)
@@ -157,39 +155,6 @@ private extension ContentSettingView {
             equals: .memo
         )
         .frame(height: 192)
-    }
-    
-    var remindSwitchRadio: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("리마인드 알림을 보내드릴까요?")
-                .pokitFont(.b2(.m))
-                .foregroundStyle(.pokit(.text(.secondary)))
-                .padding(.bottom, 12)
-            
-            PokitSwitchRadio {
-                PokitPartSwitchRadio(
-                    labelText: "안받을래요",
-                    selection: $store.isRemind,
-                    to: .no,
-                    style: .stroke
-                )
-                .background()
-                
-                PokitPartSwitchRadio(
-                    labelText: "받을래요",
-                    selection: $store.isRemind,
-                    to: .yes,
-                    style: .stroke
-                )
-                .background()
-            }
-            .padding(.bottom, 8)
-            
-            Text("일주일 후에 알림을 전송해드립니다")
-                .pokitFont(.detail1)
-                .foregroundStyle(.pokit(.text(.tertiary)))
-        }
-        .padding(.bottom, 16)
     }
 }
 private extension ContentSettingView {

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingView.swift
@@ -114,6 +114,7 @@ private extension ContentSettingView {
                 ),
                 shape: .rectangle,
                 state: $store.linkTextInputState,
+                placeholder: "링크를 입력해주세요.",
                 focusState: $focusedType,
                 equals: .link
             )
@@ -131,6 +132,7 @@ private extension ContentSettingView {
             ),
             shape: .rectangle,
             state: $store.titleTextInpuState,
+            placeholder: "제목을 입력해주세요.",
             focusState: $focusedType,
             equals: .title
         )
@@ -151,6 +153,7 @@ private extension ContentSettingView {
             text: $store.memo,
             label: "메모",
             state: $store.memoTextAreaState,
+            placeholder: "메모를 입력해주세요.",
             focusState: $focusedType,
             equals: .memo
         )

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -123,6 +123,8 @@ public struct PokitRootFeature {
             
             case 포킷추가_버튼_눌렀을때
             case 링크추가_버튼_눌렀을때
+            
+            case 미분류_카테고리_활성화
         }
     }
 
@@ -513,6 +515,10 @@ private extension PokitRootFeature {
                 
             default: return .none
             }
+        case .미분류_카테고리_활성화:
+            state.folderType = .folder(.미분류)
+            state.sortType = .sort(.최신순)
+            return .send(.inner(.sort))
         default:
             return .none
         }

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootFeature.swift
@@ -315,9 +315,11 @@ private extension PokitRootFeature {
             return .none
             
         case let .미분류_카테고리_컨텐츠_삭제_API_반영(contentId: contentId):
-            guard let index = state.domain.unclassifiedContentList.data?.firstIndex(where: { $0.id == contentId }) else {
-                return .none
-            }
+            guard
+                let index = state.domain.unclassifiedContentList.data?.firstIndex(where: {
+                    $0.id == contentId
+                })
+            else { return .none }
             state.domain.unclassifiedContentList.data?.remove(at: index)
             state.contents.removeAll { $0.content.id == contentId }
             state.isPokitDeleteSheetPresented = false

--- a/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
+++ b/Projects/Feature/FeaturePokit/Sources/PokitRootView.swift
@@ -86,13 +86,15 @@ private extension PokitRootView {
 
             Spacer()
 
-            PokitIconLTextLink(
-                store.sortType == .sort(.최신순) ?
-                "최신순" : store.folderType == .folder(.포킷) ? "이름순" : "오래된순",
-                icon: .icon(.align),
-                action: { send(.분류_버튼_눌렀을때) }
-            )
-            .contentTransition(.numericText())
+            if !store.contents.isEmpty {
+                PokitIconLTextLink(
+                    store.sortType == .sort(.최신순) ?
+                    "최신순" : store.folderType == .folder(.포킷) ? "이름순" : "오래된순",
+                    icon: .icon(.align),
+                    action: { send(.분류_버튼_눌렀을때) }
+                )
+                .contentTransition(.numericText())
+            }
         }
         .animation(.snappy(duration: 0.7), value: store.folderType)
     }

--- a/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
+++ b/Projects/Feature/FeatureRemind/Sources/Remind/RemindFeature.swift
@@ -231,11 +231,11 @@ private extension RemindFeature {
             }
         case let .즐겨찾기_이미지_조회_수행(contentId):
             return .run { [favoriteContents = state.favoriteContents] send in
-                guard let index = favoriteContents?.index(id: contentId),
-                      let content = favoriteContents?[index],
-                      let url = URL(string: content.data) else {
-                    return
-                }
+                guard
+                    let index = favoriteContents?.index(id: contentId),
+                    let content = favoriteContents?[index],
+                    let url = URL(string: content.data)
+                else { return }
                 
                 let imageURL = try await swiftSoupClient.parseOGImageURL(url)
                 guard let imageURL else { return }
@@ -247,11 +247,11 @@ private extension RemindFeature {
             }
         case let .읽지않음_이미지_조회_수행(contentId):
             return .run { [unreadContents = state.unreadContents] send in
-                guard let index = unreadContents?.index(id: contentId),
-                      let content = unreadContents?[index],
-                      let url = URL(string: content.data) else {
-                    return
-                }
+                guard
+                    let index = unreadContents?.index(id: contentId),
+                    let content = unreadContents?[index],
+                    let url = URL(string: content.data)
+                else { return }
                 let imageURL = try await swiftSoupClient.parseOGImageURL(url)
                 guard let imageURL else { return }
                 
@@ -262,11 +262,11 @@ private extension RemindFeature {
             }
         case let .리마인드_이미지_조회_수행(contentId):
             return .run { [recommendedContents = state.recommendedContents] send in
-                guard let index = recommendedContents?.index(id: contentId),
-                      let content = recommendedContents?[index],
-                      let url = URL(string: content.data) else {
-                    return
-                }
+                guard
+                    let index = recommendedContents?.index(id: contentId),
+                    let content = recommendedContents?[index],
+                    let url = URL(string: content.data)
+                else { return }
                 let imageURL = try await swiftSoupClient.parseOGImageURL(url)
                 guard let imageURL else { return }
                 

--- a/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Alert/PokitAlertBoxFeature.swift
@@ -146,7 +146,11 @@ private extension PokitAlertBoxFeature {
             return .none
             
         case let .알람_삭제_API_반영(item):
-            guard let idx = state.domain.alertList.data?.firstIndex(where: { $0 == item }) else { return .none }
+            guard
+                let idx = state.domain.alertList.data?.firstIndex(where: {
+                    $0 == item
+                })
+            else { return .none }
             state.domain.alertList.data?.remove(at: idx)
             return .none
         }

--- a/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
+++ b/Projects/Feature/FeatureSetting/Sources/Search/PokitSearchFeature.swift
@@ -236,10 +236,11 @@ private extension PokitSearchFeature {
             return .send(.inner(.filterBottomSheet(filterType: .contentType)))
             
         case .기간_버튼_눌렀을때:
-            guard state.domain.condition.startDate != nil && state.domain.condition.endDate != nil else {
+            guard
+                state.domain.condition.startDate != nil &&
+                state.domain.condition.endDate != nil
                 /// - 선택된 기간이 없을 경우
-                return .send(.inner(.filterBottomSheet(filterType: .date)))
-            }
+            else { return .send(.inner(.filterBottomSheet(filterType: .date))) }
             state.domain.condition.startDate = nil
             state.domain.condition.endDate = nil
             return .run { send in
@@ -323,8 +324,7 @@ private extension PokitSearchFeature {
             state.domain.condition.startDate = startDate
             state.domain.condition.endDate = endDate
             
-            guard let startDate,
-                  let endDate else {
+            guard let startDate, let endDate else {
                 /// 🚨 Error Case : 날짜 필터가 선택 안되었을 경우
                 state.dateFilterText = "기간"
                 return .none
@@ -513,9 +513,10 @@ private extension PokitSearchFeature {
     func handleDelegateAction(_ action: Action.DelegateAction, state: inout State) -> Effect<Action> {
         switch action {
         case .컨텐츠_검색:
-            guard let contentList = state.domain.contentList.data, !contentList.isEmpty else {
-                return .none
-            }
+            guard
+                let contentList = state.domain.contentList.data,
+                !contentList.isEmpty
+            else { return .none }
             return .send(.async(.컨텐츠_검색_API), animation: .pokitSpring)
         default: return .none
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

#167 

## 📝작업 내용
- 미분류 페이지에서 컨텐츠가 비어있을 경우 정렬버튼 숨기기
- 링크 추가 페이지에서 링크 텍스트 지우기 버튼 눌렀을 때 제목도 함께 지우기
- 링크 추가 페이지에서 리마인드 선택 영역 삭제
- 링크 저장 완료 팝업 눌렀을 시에 해당 링크의 포킷(미분류) 페이지로 이동
-  메모 수정 시 키보드 툴바(취소, 완료 버튼) 추가
- 링크 추가 페이지에서 텍스트 필드 placeholder 문구 수정
- 포킷 선택 바텀 시트 디자인 수정
- 링크 미리보기에서 스켈레톤에 그림자 제거
- 'PokitLinkCard' 디자인 변경 사항 반영
-  컨텐츠 상세 페이지에서 포킷명 뱃지 위치 수정
- 'PokitListButton' 디자인 수정

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2024-12-10 at 15 50 57](https://github.com/user-attachments/assets/2247ed25-495f-4fb9-8a9f-8345ce9dd23a)|![Simulator Screen Recording - iPhone 16 Pro - 2024-12-10 at 15 51 13](https://github.com/user-attachments/assets/da22fa64-1851-4078-9a71-f4289ba76b8f)|![Simulator Screen Recording - iPhone 16 Pro - 2024-12-10 at 15 52 03](https://github.com/user-attachments/assets/b23cc324-7e94-4d34-8269-45d1717e942a)
--- | --- | ---

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
```Swift
case let .카테고리상세_이동(category):
  if category.categoryName == "미분류" {
      state.selectedTab = .pokit
      state.path.removeAll()
      return .send(.pokit(.delegate(.미분류_카테고리_활성화)))
  }
  state.path.append(.카테고리상세(.init(category: category)))
  return .none
```
- 링크 저장 팝업 클릭 시 알맞는 포킷 페이지로 이동하기 위해 미분류 포킷과 일반 포킷을 단순히 `categoryName`을 비교하여 분기하고 있습니다.(단순 이름 비교라 좀 맘에 안들기도 함...)
사용자 별로 미분류 포킷 id가 다르기 때문에 이렇게 하였고, 저번 pr 처럼 `"미분류"`라는 문자열을 `Constant`로 넣으면 좋을지..? 궁금합니다

close #167 
