### PR TITLE
feat: [2.0.0] 버전 업데이트에 따른 기능 추가 및 수정(카테고리 상세)

### DIFF
--- a/Projects/App/Sources/MainTab/MainTabPath.swift
+++ b/Projects/App/Sources/MainTab/MainTabPath.swift
@@ -171,6 +171,11 @@ public extension MainTabFeature {
                 state.path.append(.링크추가및수정(ContentSettingFeature.State(urlText: state.link)))
                 state.link = nil
                 return .none
+                
+            case let .path(.element(_, action: .카테고리상세(.delegate(.링크추가(categoryId))))):
+                state.categoryId = categoryId
+                state.path.append(.링크추가및수정(ContentSettingFeature.State()))
+                return .none
 
             /// - 링크추가 및 수정에서 저장하기 눌렀을 때
             case let .path(.element(stackElementId, action: .링크추가및수정(.delegate(.저장하기_완료(contentId))))):

--- a/Projects/DSKit/Sources/Components/PokitBottomSheet.swift
+++ b/Projects/DSKit/Sources/Components/PokitBottomSheet.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 
 public struct PokitBottomSheet: View {
+    @State
+    private var height: CGFloat
     private let items: [Item]
-    private let height: CGFloat
     private let delegateSend: ((PokitBottomSheet.Delegate) -> Void)?
     
     public init(
         items: [Item],
-        height: CGFloat,
+        height: CGFloat = 0,
         delegateSend: ((PokitBottomSheet.Delegate) -> Void)?
     ) {
         self.items = items
@@ -30,6 +31,16 @@ public struct PokitBottomSheet: View {
         .presentationDetents([.height(height)])
         .pokitPresentationCornerRadius()
         .pokitPresentationBackground()
+        .readHeight()
+        .onPreferenceChange(HeightPreferenceKey.self) { height in
+            if let height {
+                print("height:", height)
+                self.height = height
+            }
+        }
+        .ignoresSafeArea(.all)
+        .padding(.top, 12)
+        .padding(.bottom, -20)
     }
     
     @ViewBuilder
@@ -120,3 +131,18 @@ public extension PokitBottomSheet {
     }
 }
 
+@available(iOS 18.0, *)
+#Preview {
+    @Previewable
+    @State var isPresented: Bool = true
+    
+    ZStack {
+        Color.green.ignoresSafeArea()
+    }
+    .sheet(isPresented: $isPresented) {
+        PokitBottomSheet(
+            items: [.share, .edit, .delete],
+            delegateSend: { _ in }
+        )
+    }
+}

--- a/Projects/DSKit/Sources/Components/PokitCaution.swift
+++ b/Projects/DSKit/Sources/Components/PokitCaution.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public enum CautionType {
     case 카테고리없음
     case 미분류_링크없음
+    case 포킷상세_링크없음
     case 링크없음
     case 즐겨찾기_링크없음
     case 링크부족
@@ -17,12 +18,13 @@ public enum CautionType {
     
     var image: PokitImage.Character {
         switch self {
-        case .카테고리없음, .링크없음, .즐겨찾기_링크없음, .미분류_링크없음:
-            return .empty
         case .링크부족:
             return .sad
+            
         case .알림없음:
             return .pooki
+            
+        default: return .empty
         }
     }
     
@@ -32,7 +34,7 @@ public enum CautionType {
             return "저장된 포킷이 없어요!"
         case .미분류_링크없음:
             return "미분류 링크가 없어요!"
-        case .링크없음:
+        case .링크없음, .포킷상세_링크없음:
             return "저장된 링크가 없어요!"
         case .즐겨찾기_링크없음:
             return "즐겨찾기 링크가 없어요!"
@@ -49,6 +51,8 @@ public enum CautionType {
             return "포킷을 생성해 링크를 저장해보세요"
         case .미분류_링크없음:
             return "링크를 포킷에 깔끔하게 분류하셨어요"
+        case .포킷상세_링크없음:
+            return "포킷에 링크를 저장해보세요"
         case .링크없음:
             return "다양한 링크를 한 곳에 저장해보세요"
         case .즐겨찾기_링크없음:
@@ -64,7 +68,7 @@ public enum CautionType {
         switch self {
         case .카테고리없음:
             return "포킷 추가하기"
-        case .미분류_링크없음:
+        case .미분류_링크없음, .포킷상세_링크없음:
             return "링크 추가하기"
         default: return nil
         }

--- a/Projects/DSKit/Sources/Modifiers/PokitFloatButtonModifier.swift
+++ b/Projects/DSKit/Sources/Modifiers/PokitFloatButtonModifier.swift
@@ -1,0 +1,44 @@
+//
+//  PokitFloatButtonModifier.swift
+//  DSKit
+//
+//  Created by 김민호 on 1/16/25.
+//
+import SwiftUI
+
+private struct PokitFloatButtonModifier: ViewModifier {
+    let action: () -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottomTrailing) {
+                Button(action: action) {
+                    Image(.icon(.plus))
+                        .resizable()
+                        .frame(width: 36, height: 36)
+                        .padding(12)
+                        .foregroundStyle(.pokit(.icon(.inverseWh)))
+                        .background {
+                            RoundedRectangle(cornerRadius: 9999, style: .continuous)
+                                .fill(.pokit(.bg(.brand)))
+                        }
+                        .frame(width: 60, height: 60)
+                }
+                .padding(.trailing, 20)
+                .padding(.bottom, 39)
+            }
+    }
+}
+
+public extension View {
+    func pokitFloatButton(action: @escaping () -> Void) -> some View {
+        return self.modifier(PokitFloatButtonModifier(action: action))
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+            .pokitFloatButton(action: {})
+    }
+}

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -40,6 +40,9 @@ public struct CategoryDetailFeature {
         var isFavoriteFiltered: Bool {
             get { domain.condition.isFavoriteFlitered }
         }
+        var isFavoriteCategory: Bool {
+            get { domain.category.isFavorite }
+        }
         
         var sortType: SortType = .최신순
         var categories: IdentifiedArrayOf<BaseCategoryItem>? {

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -83,6 +83,8 @@ public struct CategoryDetailFeature {
             case binding(BindingAction<State>)
             case dismiss
             case pagenation
+            
+            case 공유_버튼_눌렀을때
             case 카테고리_케밥_버튼_눌렀을때
             case 카테고리_선택_버튼_눌렀을때
             case 카테고리_선택했을때(BaseCategoryItem)
@@ -172,6 +174,16 @@ private extension CategoryDetailFeature {
     func handleViewAction(_ action: Action.View, state: inout State) -> Effect<Action> {
         switch action {
         case .binding:
+            return .none
+            
+        case .공유_버튼_눌렀을때:
+            kakaoShareClient.카테고리_카카오톡_공유(
+                CategoryKaKaoShareModel(
+                    categoryName: state.domain.category.categoryName,
+                    categoryId: state.domain.category.id,
+                    imageURL: state.domain.category.categoryImage.imageURL
+                )
+            )
             return .none
             
         case .카테고리_케밥_버튼_눌렀을때:
@@ -348,14 +360,6 @@ private extension CategoryDetailFeature {
         case .categoryBottomSheet(let delegateAction):
             switch delegateAction {
             case .shareCellButtonTapped:
-                kakaoShareClient.카테고리_카카오톡_공유(
-                    CategoryKaKaoShareModel(
-                        categoryName: state.domain.category.categoryName,
-                        categoryId: state.domain.category.id,
-                        imageURL: state.domain.category.categoryImage.imageURL
-                    )
-                )
-                state.isCategorySheetPresented = false
                 return .none
             case .editCellButtonTapped:
                 return .run { [category = state.category] send in

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailFeature.swift
@@ -90,6 +90,7 @@ public struct CategoryDetailFeature {
             case 카테고리_선택했을때(BaseCategoryItem)
             case 필터_버튼_눌렀을때
             case 뷰가_나타났을때
+            case 링크_추가_버튼_눌렀을때
         }
         
         public enum InnerAction: Equatable {
@@ -121,6 +122,7 @@ public struct CategoryDetailFeature {
             case contentItemTapped(BaseContentItem)
             case linkCopyDetected(URL?)
             case 링크수정(contentId: Int)
+            case 링크추가(categoryId: Int)
             case 포킷삭제
             case 포킷수정(BaseCategoryItem)
             case 포킷공유
@@ -185,6 +187,10 @@ private extension CategoryDetailFeature {
                 )
             )
             return .none
+            
+        case .링크_추가_버튼_눌렀을때:
+            let id = state.category.id
+            return .send(.delegate(.링크추가(categoryId: id)))
             
         case .카테고리_케밥_버튼_눌렀을때:
             return .run { send in await send(.inner(.카테고리_시트_활성화(true))) }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -41,8 +41,7 @@ public extension CategoryDetailView {
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isCategorySheetPresented) {
                 PokitBottomSheet(
-                    items: [.share, .edit, .delete],
-                    height: 224,
+                    items: [.edit, .delete],
                     delegateSend: { store.send(.scope(.categoryBottomSheet($0))) }
                 )
             }
@@ -164,7 +163,7 @@ private extension CategoryDetailView {
                 state: .filled(.primary),
                 size: .medium,
                 shape: .round,
-                action: {}
+                action: { send(.공유_버튼_눌렀을때) }
             )
         }
     }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -37,7 +37,25 @@ public extension CategoryDetailView {
             .padding(.horizontal, 20)
             .padding(.top, 12)
             .pokitNavigationBar { navigationBar }
-            .pokitFloatButton(action: { send(.링크_추가_버튼_눌렀을때) })
+            //TODO: overlay(condition) merge 시 수정
+            .overlay(alignment: .bottomTrailing) {
+                if !store.contents.isEmpty {
+                    Button(action: { send(.링크_추가_버튼_눌렀을때) }) {
+                        Image(.icon(.plus))
+                            .resizable()
+                            .frame(width: 36, height: 36)
+                            .padding(12)
+                            .foregroundStyle(.pokit(.icon(.inverseWh)))
+                            .background {
+                                RoundedRectangle(cornerRadius: 9999, style: .continuous)
+                                    .fill(.pokit(.bg(.brand)))
+                            }
+                            .frame(width: 60, height: 60)
+                    }
+                    .padding(.trailing, 20)
+                    .padding(.bottom, 39)
+                }
+            }
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isCategorySheetPresented) {
                 PokitBottomSheet(
@@ -160,34 +178,37 @@ private extension CategoryDetailView {
         }
     }
     
+    @ViewBuilder
     var filterHeader: some View {
-        HStack(spacing: 8) {
-            PokitTextButton(
-                "즐겨찾기",
-                state: store.isFavoriteFiltered
-                ? .filled(.primary)
-                : .default(.secondary),
-                size: .small,
-                shape: .round,
-                action: { send(.분류_버튼_눌렀을때(.즐겨찾기)) }
-            )
-            PokitTextButton(
-                "안읽음",
-                state: store.isUnreadFiltered
-                ? .filled(.primary)
-                : .default(.secondary),
-                size: .small,
-                shape: .round,
-                action: { send(.분류_버튼_눌렀을때(.안읽음)) }
-            )
-            
-            Spacer()
-            PokitIconLTextLink(
-                store.sortType.title,
-                icon: .icon(.align),
-                action: { send(.정렬_버튼_눌렀을때) }
-            )
-            .contentTransition(.numericText())
+        if !store.contents.isEmpty {
+            HStack(spacing: 8) {
+                PokitTextButton(
+                    "즐겨찾기",
+                    state: store.isFavoriteFiltered
+                    ? .filled(.primary)
+                    : .default(.secondary),
+                    size: .small,
+                    shape: .round,
+                    action: { send(.분류_버튼_눌렀을때(.즐겨찾기)) }
+                )
+                PokitTextButton(
+                    "안읽음",
+                    state: store.isUnreadFiltered
+                    ? .filled(.primary)
+                    : .default(.secondary),
+                    size: .small,
+                    shape: .round,
+                    action: { send(.분류_버튼_눌렀을때(.안읽음)) }
+                )
+                
+                Spacer()
+                PokitIconLTextLink(
+                    store.sortType.title,
+                    icon: .icon(.align),
+                    action: { send(.정렬_버튼_눌렀을때) }
+                )
+                .contentTransition(.numericText())
+            }
         }
     }
     
@@ -196,8 +217,10 @@ private extension CategoryDetailView {
             if !store.isLoading {
                 if store.contents.isEmpty {
                     VStack {
-                        PokitCaution(type: .링크없음)
-                            .padding(.top, 20)
+                        PokitCaution(
+                            type: .포킷상세_링크없음,
+                            action: { send(.링크_추가_버튼_눌렀을때) }
+                        )
                         
                         Spacer()
                     }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -64,14 +64,6 @@ public extension CategoryDetailView {
                     delegateSend: { store.send(.scope(.categoryDeleteBottomSheet($0))) }
                 )
             }
-            .sheet(isPresented: $store.isFilterSheetPresented) {
-                CategoryFilterSheet(
-                    sortType: $store.sortType,
-                    isBookMarkSelected: store.isFavoriteFiltered,
-                    isUnreadSeleected: store.isUnreadFiltered,
-                    delegateSend: { store.send(.scope(.filterBottomSheet($0))) }
-                )
-            }
             .task { await send(.뷰가_나타났을때).finish() }
         }
     }
@@ -172,24 +164,28 @@ private extension CategoryDetailView {
         HStack(spacing: 8) {
             PokitTextButton(
                 "즐겨찾기",
-                state: .filled(.primary),
+                state: store.isFavoriteFiltered
+                ? .filled(.primary)
+                : .default(.secondary),
                 size: .small,
                 shape: .round,
-                action: {}
+                action: { send(.분류_버튼_눌렀을때(.즐겨찾기)) }
             )
             PokitTextButton(
                 "안읽음",
-                state: .filled(.primary),
+                state: store.isUnreadFiltered
+                ? .filled(.primary)
+                : .default(.secondary),
                 size: .small,
                 shape: .round,
-                action: {}
+                action: { send(.분류_버튼_눌렀을때(.안읽음)) }
             )
             
             Spacer()
             PokitIconLTextLink(
-                "최신순",
+                store.sortType.title,
                 icon: .icon(.align),
-                action: {}
+                action: { send(.정렬_버튼_눌렀을때) }
             )
             .contentTransition(.numericText())
         }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -37,7 +37,7 @@ public extension CategoryDetailView {
             .padding(.horizontal, 20)
             .padding(.top, 12)
             .pokitNavigationBar { navigationBar }
-            .pokitFloatButton(action: {})
+            .pokitFloatButton(action: { send(.링크_추가_버튼_눌렀을때) })
             .ignoresSafeArea(edges: .bottom)
             .sheet(isPresented: $store.isCategorySheetPresented) {
                 PokitBottomSheet(
@@ -147,7 +147,7 @@ private extension CategoryDetailView {
                         .resizable()
                         .frame(width: 16, height: 16)
                         .foregroundStyle(iconColor)
-                    Text("\(store.category.contentCount)개")
+                    Text("\(store.contents.count)개")
                         .foregroundStyle(textColor)
                         .pokitFont(.b2(.m))
                 }

--- a/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
+++ b/Projects/Feature/FeatureCategoryDetail/Sources/CategoryDetailView.swift
@@ -96,11 +96,13 @@ private extension CategoryDetailView {
                     action: { send(.dismiss) }
                 )
             }
-            PokitHeaderItems(placement: .trailing) {
-                PokitToolbarButton(
-                    .icon(.kebab),
-                    action: { send(.카테고리_케밥_버튼_눌렀을때) }
-                )
+            if !store.isFavoriteCategory {
+                PokitHeaderItems(placement: .trailing) {
+                    PokitToolbarButton(
+                        .icon(.kebab),
+                        action: { send(.카테고리_케밥_버튼_눌렀을때) }
+                    )
+                }
             }
         }
         .padding(.top, 8)
@@ -137,69 +139,82 @@ private extension CategoryDetailView {
                 .buttonStyle(.plain)
             }
             .padding(.bottom, 8)
-            HStack(spacing: 3.5) {
-                let iconColor: Color = .pokit(.icon(.secondary))
-                let textColor: Color = .pokit(.text(.tertiary))
-                
-                if store.category.openType == .비공개 {
+            if !store.isFavoriteCategory {
+                HStack(spacing: 3.5) {
+                    let iconColor: Color = .pokit(.icon(.secondary))
+                    let textColor: Color = .pokit(.text(.tertiary))
+                    
+                    if store.category.openType == .비공개 {
+                        HStack(spacing: 2) {
+                            Image(.icon(.lock))
+                                .resizable()
+                                .frame(width: 16, height: 16)
+                                .foregroundStyle(iconColor)
+                            Text("비밀")
+                                .foregroundStyle(textColor)
+                                .pokitFont(.b2(.m))
+                        }
+                    }
                     HStack(spacing: 2) {
-                        Image(.icon(.lock))
+                        Image(.icon(.link))
                             .resizable()
                             .frame(width: 16, height: 16)
                             .foregroundStyle(iconColor)
-                        Text("비밀")
+                        Text("\(store.contents.count)개")
                             .foregroundStyle(textColor)
                             .pokitFont(.b2(.m))
                     }
-                }
-                HStack(spacing: 2) {
-                    Image(.icon(.link))
-                        .resizable()
-                        .frame(width: 16, height: 16)
-                        .foregroundStyle(iconColor)
-                    Text("\(store.contents.count)개")
+                    Text("#\(store.category.keywordType.title)")
                         .foregroundStyle(textColor)
                         .pokitFont(.b2(.m))
+                        .padding(.leading, 4.5)
                 }
-                Text("#\(store.category.keywordType.title)")
-                    .foregroundStyle(textColor)
-                    .pokitFont(.b2(.m))
-                    .padding(.leading, 4.5)
+                .padding(.bottom, 16)
+                PokitIconLButton(
+                    "공유",
+                    .icon(.share),
+                    state: .filled(.primary),
+                    size: .medium,
+                    shape: .round,
+                    action: { send(.공유_버튼_눌렀을때) }
+                )
             }
-            .padding(.bottom, 16)
-            PokitIconLButton(
-                "공유",
-                .icon(.share),
-                state: .filled(.primary),
-                size: .medium,
-                shape: .round,
-                action: { send(.공유_버튼_눌렀을때) }
-            )
         }
     }
     
     @ViewBuilder
     var filterHeader: some View {
+        let isFavoriteCategory = store.isFavoriteCategory
         if !store.contents.isEmpty {
-            HStack(spacing: 8) {
-                PokitTextButton(
-                    "즐겨찾기",
-                    state: store.isFavoriteFiltered
-                    ? .filled(.primary)
-                    : .default(.secondary),
-                    size: .small,
-                    shape: .round,
-                    action: { send(.분류_버튼_눌렀을때(.즐겨찾기)) }
-                )
-                PokitTextButton(
-                    "안읽음",
-                    state: store.isUnreadFiltered
-                    ? .filled(.primary)
-                    : .default(.secondary),
-                    size: .small,
-                    shape: .round,
-                    action: { send(.분류_버튼_눌렀을때(.안읽음)) }
-                )
+            HStack(spacing: isFavoriteCategory ? 2 : 8) {
+                if isFavoriteCategory {
+                    Image(.icon(.link))
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        .foregroundStyle(.pokit(.icon(.secondary)))
+                    Text("\(store.contents.count)개")
+                        .foregroundStyle(.pokit(.text(.tertiary)))
+                        .pokitFont(.b2(.m))
+                } else {
+                    PokitTextButton(
+                        "즐겨찾기",
+                        state: store.isFavoriteFiltered
+                        ? .filled(.primary)
+                        : .default(.secondary),
+                        size: .small,
+                        shape: .round,
+                        action: { send(.분류_버튼_눌렀을때(.즐겨찾기)) }
+                    )
+                    PokitTextButton(
+                        "안읽음",
+                        state: store.isUnreadFiltered
+                        ? .filled(.primary)
+                        : .default(.secondary),
+                        size: .small,
+                        shape: .round,
+                        action: { send(.분류_버튼_눌렀을때(.안읽음)) }
+                    )
+                }
                 
                 Spacer()
                 PokitIconLTextLink(

--- a/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
+++ b/Projects/Feature/FeatureContentSetting/Sources/ContentSetting/ContentSettingFeature.swift
@@ -212,6 +212,7 @@ private extension ContentSettingFeature {
             
             return .send(.delegate(.포킷추가하기))
         case .뒤로가기_버튼_눌렀을때:
+            state.categoryId = nil
             return state.isShareExtension
             ? .send(.delegate(.dismiss))
             : .run { _ in await dismiss() }


### PR DESCRIPTION
## #️⃣연관된 이슈

#183 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

2.0버전의 포킷 상세화면 작업을 했습니다.
기능적인 구현보다 디자인적 요소가 많았던 작업입니다. 
- 카테고리 내 링크가 없을 때 화면 분기 추가
- 링크추가하기 float button
- 즐겨찾기 상세화면
- 이 외 기능 위치 수정
- 필터링 다중 선택 가능하게끔 수정

### 스크린샷 (선택)
| <img src="https://github.com/user-attachments/assets/d0af3953-5b49-4ed7-80df-dcc3c84cb99b" width="200"> | <img src="https://github.com/user-attachments/assets/2ba7d9e2-b62f-479c-b142-111b77e470f7" width="200"> | 
|:-:|:-:|
|`즐겨찾기 상세` | `카테고리 상세` |

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

로직상 문제는 없지만 2.0버전을 준비하면서 몇몇 API가 작동하지 않는 것을 확인했습니다. 또한 겹치는 API도 여럿 있는 상태고 하나하나 잡다가 더 지연될 것 같아서요.

ex) 즐겨찾기 컨텐츠 목록을 조회하기 위해 카테고리 내 컨텐츠 목록 조회를 사용해야 할까..?, 아니면 즐겨찾기 링크 모음 조회를 사용해야할까..?
(두 API의 response가 동일하기 때문에 ... 즐겨찾기 카테고리 목록을 굳이 뽑아써야 할까? 라는 의문이 들어서 내 컨텐츠 목록조회로 즐겨찾기 목록 뽑은 상태... 근데 빈값 반환)

2.0 작업들 전부 끝내고 릴리즈 전 QA때 한번에 잡아내는게 시간절약이 된다고 생각하는데 어떠신가요?? 

close #183
